### PR TITLE
Turboを無効化

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,8 +2,9 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "@fortawesome/fontawesome-free/js/all";
+Turbo.session.drive = false;
 
-document.addEventListener("turbo:load", () => {
+document.addEventListener("DOMContentLoaded", () => {
   let currentQuestion = 1;
   const totalQuestions = 10;
 


### PR DESCRIPTION
再度診断して、戻るボタンをクリックすると質問が２つ表示されしまうバグが発生していたので修正しました。

Turbo Driveがページ遷移の速度を向上させるためにページ全体のリロードせずに一部の部分だけ置き換えるような処理をするためJavaScriptの状態やイベントリスナーが保持されて上記のようなバグが発生したと考えられます。
Turboを無効化に設定に設定したら、バグは無くなりました。
他の原因も考えられるので、もう少し調査します。